### PR TITLE
Fix crash when specified locale provides no country

### DIFF
--- a/Planet.podspec
+++ b/Planet.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'Planet'
-  s.version      = '0.2.1'
+  s.version      = '0.3.1'
   s.summary      = 'A country picker'
   s.description  = 'A country picker view controller'
   s.homepage     = 'https://github.com/kwallet/planet'

--- a/Planet/Country.swift
+++ b/Planet/Country.swift
@@ -66,4 +66,11 @@ extension Country {
     public static func find(callingCode: String, locale: Locale = .current) -> Country? {
         return all(locale: locale).filter { $0.callingCode == callingCode } .first
     }
+
+    public static func currentCountryCode(currentSystemLocale: Locale = .current, formattingLocale: Locale = .current) -> String? {
+        if let countryCode = (currentSystemLocale as NSLocale).object(forKey: NSLocale.Key.countryCode) as? String {
+            return countryCode
+        }
+        return (formattingLocale as NSLocale).object(forKey: NSLocale.Key.countryCode) as? String
+    }
 }

--- a/Planet/CountryDataSource.swift
+++ b/Planet/CountryDataSource.swift
@@ -23,7 +23,7 @@ class CountryDataSource {
         var currentCountries: [Country] = []
         var otherCountries: [Country] = []
         
-        let currentCountryCode = (locale as NSLocale).object(forKey: NSLocale.Key.countryCode) as! String
+        let currentCountryCode = Country.currentCountryCode(currentSystemLocale: Locale.current, formattingLocale: locale)
         
         for countryCode in countryCodes {
             if let country = Country.find(isoCode: countryCode, locale: locale) {

--- a/PlanetTests/CountryTests.swift
+++ b/PlanetTests/CountryTests.swift
@@ -27,4 +27,14 @@ class CountryTests: XCTestCase {
         XCTAssertEqual(country?.isoCode, "AT")
         XCTAssertEqual(country?.callingCode, "+43")
     }
+
+    func testAustriaInNonRegionalGerman() {
+        let locale = Locale(identifier: "de")
+        let country = Country.find(isoCode: "AT", locale: locale)
+
+        XCTAssertEqual(country?.name, "Österreich")
+        XCTAssertEqual(country?.isoCode, "AT")
+        XCTAssertEqual(country?.callingCode, "+43")
+    }
+
 }

--- a/PlanetTests/PlanetTests.swift
+++ b/PlanetTests/PlanetTests.swift
@@ -58,4 +58,19 @@ class PlanetTests: XCTestCase {
         
         XCTAssertNil(notIncludedCountry)
     }
+
+    func testDataSourceWithNonRegionalLocale() {
+        let locale = Locale(identifier: "en")
+        let dataSource = CountryDataSource(locale: locale, countryCodes: ["AT", "DE", "CH"])
+
+        XCTAssertEqual(dataSource.count(1), 3)
+
+        let includedCountry = dataSource.find("Austria").first
+
+        XCTAssertEqual(includedCountry?.isoCode, "AT")
+
+        let notIncludedCountry = dataSource.find("United States").first
+
+        XCTAssertNil(notIncludedCountry)
+    }
 }


### PR DESCRIPTION
When setting a locale with identifier like `"en"` or `"de"` the datasource crashed when force unwrapping the locale's country. To come up with a current country the `Locale.current` is now used as a fallback (or no current country is used without crash).
This fallback logic makes sense when you consider a german user using an only english localized App, so you expect country names formatted in english to be consistent with UI, but current locale is say `"de_DE"`, so germany will still be moved to top of country list.